### PR TITLE
Загружаем версию Bootstrap содержащую только глиф-иконки

### DIFF
--- a/icon_glyph/icon_glyph.html
+++ b/icon_glyph/icon_glyph.html
@@ -5,8 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <script src="https://api-maps.yandex.ru/2.1/?lang=ru_RU" type="text/javascript"></script>
 
-    <!-- Обратите внимание, что для добавления на карту меток, содержащих глиф-иконки, нужно подключить Bootstrap-->
-    <link rel="stylesheet" type="text/css" href="https://yastatic.net/bootstrap/3.3.4/css/bootstrap.min.css">
+    <!-- Загружаем версию Bootstrap содержащую только глиф-иконки-->
+    <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
     <script src="icon_glyph.js" type="text/javascript"></script>
 	<style>
         html, body, #map {


### PR DESCRIPTION
Необходимо для того чтобы починить баг связанный с печатью