### PR TITLE
12799 : Правки существующего примера

### DIFF
--- a/regions/regions.js
+++ b/regions/regions.js
@@ -62,7 +62,7 @@ var REGIONS_DATA = {
     },
     // Шаблон html-содержимого макета.
     optionsTemplate = [
-        '<div style="line-height: 34px; background-color: #80808080;" id="regions-params">',
+        '<div style="line-height: 34px;" id="regions-params">',
         '{% for paramName, param in data.params %}',
         '{% for key, value in state.values %}',
         '{% if key == paramName %}',
@@ -153,10 +153,41 @@ function init() {
                 this.regions
                     .add(res.features.map(function (feature) {
                         feature.id = feature.properties.iso3166;
+                        feature.options = {
+                            strokeColor: '#ffffff',
+                            strokeOpacity: 0.4,
+                            fillColor: '#6961b0',
+                            fillOpacity: 0.8,
+                            hintCloseTimeout: 0,
+                            hintOpenTimeout: 0
+                        };
                         return feature;
                     }));
-
                 map.geoObjects.add(this.regions);
+
+                this.paintedRegion = '';
+                this.regions.events
+                    .add('mouseenter', function (e) {
+                        var id = e.get('objectId');
+                        this.regions.objects.setObjectOptions(id, {strokeWidth: 2});
+                    }, this)
+                    .add('mouseleave', function (e) {
+                        var id = e.get('objectId');
+                        if (this.paintedRegion !== id) {
+                            this.regions.objects.setObjectOptions(id, {strokeWidth: 1});
+                        }
+                    }, this)
+                    .add('click', function (e) {
+                        var id = e.get('objectId');
+                        if (this.paintedRegion) {
+                            this.regions.objects.setObjectOptions(this.paintedRegion, {
+                                strokeWidth: 1,
+                                fillColor: '#6961b0'
+                            });
+                        }
+                        this.regions.objects.setObjectOptions(id, {strokeWidth: 2, fillColor: '#3B3781'});
+                        this.paintedRegion = id;
+                    }, this);
                 this.getMap().setBounds(
                     this.regions.getBounds(),
                     {checkZoomRange: true}
@@ -184,8 +215,8 @@ function init() {
             state: {
                 enabled: true,
                 values: {
-                    region: 'RU',
-                    lang: 'ru',
+                    region: 'TR',
+                    lang: 'tr',
                     quality: '1'
                 }
             },

--- a/regions/regions.js
+++ b/regions/regions.js
@@ -165,7 +165,7 @@ function init() {
                     }));
                 map.geoObjects.add(this.regions);
 
-                this.paintedRegion = '';
+                this.selectedRegionId = '';
                 this.regions.events
                     .add('mouseenter', function (e) {
                         var id = e.get('objectId');
@@ -173,20 +173,20 @@ function init() {
                     }, this)
                     .add('mouseleave', function (e) {
                         var id = e.get('objectId');
-                        if (this.paintedRegion !== id) {
+                        if (this.selectedRegionId !== id) {
                             this.regions.objects.setObjectOptions(id, {strokeWidth: 1});
                         }
                     }, this)
                     .add('click', function (e) {
                         var id = e.get('objectId');
-                        if (this.paintedRegion) {
-                            this.regions.objects.setObjectOptions(this.paintedRegion, {
+                        if (this.selectedRegionId) {
+                            this.regions.objects.setObjectOptions(this.selectedRegionId, {
                                 strokeWidth: 1,
                                 fillColor: '#6961b0'
                             });
                         }
                         this.regions.objects.setObjectOptions(id, {strokeWidth: 2, fillColor: '#3B3781'});
-                        this.paintedRegion = id;
+                        this.selectedRegionId = id;
                     }, this);
                 this.getMap().setBounds(
                     this.regions.getBounds(),


### PR DESCRIPTION
- убрать цвет с серой подложки под кнопками (хорошо, что это некликабельная область, но не нужно её делать видимой)
- изменить дефолтный вьюпорт на Турцию
- цвет обводки     #ffffff opacity 40%
- цвет заливки     #6961b0 opacity 80%
По ховеру
- хинт открывается и закрывается моментально
 - толщина обводки +2px
По клику
 - меняем цвет и обводку региона до следующего выбранного региона